### PR TITLE
feat: :sparkles: add search all products by UUID list

### DIFF
--- a/src/main/java/br/com/fiap/tech_challenge/adapters/driven/infra/entities/ProductEntity.java
+++ b/src/main/java/br/com/fiap/tech_challenge/adapters/driven/infra/entities/ProductEntity.java
@@ -37,6 +37,8 @@ public class ProductEntity {
     @UpdateTimestamp
     private LocalDateTime updatedAt;
 
+    public ProductEntity() {}
+
     public ProductEntity(UUID id, String name, CategoryProductEnum category, BigDecimal price, String description) {
         this.id = id;
         this.name = name;

--- a/src/main/java/br/com/fiap/tech_challenge/adapters/driven/infra/repository/ProductPersistenceImpl.java
+++ b/src/main/java/br/com/fiap/tech_challenge/adapters/driven/infra/repository/ProductPersistenceImpl.java
@@ -5,6 +5,9 @@ import br.com.fiap.tech_challenge.core.domain.models.Product;
 import br.com.fiap.tech_challenge.core.domain.ports.ProductPersistence;
 import org.springframework.stereotype.Component;
 
+import java.util.List;
+import java.util.UUID;
+
 @Component
 public class ProductPersistenceImpl implements ProductPersistence {
 
@@ -19,6 +22,12 @@ public class ProductPersistenceImpl implements ProductPersistence {
         var productEntity = new ProductEntity(product);
         var productSaved = repository.save(productEntity);
         return productSaved.toProduct();
+    }
+
+    @Override
+    public List<Product> findAllByIds(List<UUID> ids) {
+        var products = repository.findAllById(ids);
+        return products.stream().map(ProductEntity::toProduct).toList();
     }
 
 }

--- a/src/main/java/br/com/fiap/tech_challenge/core/domain/ports/ProductPersistence.java
+++ b/src/main/java/br/com/fiap/tech_challenge/core/domain/ports/ProductPersistence.java
@@ -2,8 +2,12 @@ package br.com.fiap.tech_challenge.core.domain.ports;
 
 import br.com.fiap.tech_challenge.core.domain.models.Product;
 
+import java.util.List;
+import java.util.UUID;
+
 public interface ProductPersistence {
 
     Product create(Product product);
+    List<Product> findAllByIds(List<UUID> ids);
 
 }


### PR DESCRIPTION
# Implement search for products by a list of IDs

- Updated `ProductEntity` with a new empty constructor because JPA needed.
- Updated `ProductPersistenceImpl` to create new methor to search all products filtered by list of UUID's.

This implementation was necessary to support the order creation flow, which requires product data based on provided IDs.