### PR TITLE
feat: :sparkles: add order entities and persistence

### DIFF
--- a/src/main/java/br/com/fiap/tech_challenge/adapters/driven/infra/entities/OrderEntity.java
+++ b/src/main/java/br/com/fiap/tech_challenge/adapters/driven/infra/entities/OrderEntity.java
@@ -1,0 +1,72 @@
+package br.com.fiap.tech_challenge.adapters.driven.infra.entities;
+
+import br.com.fiap.tech_challenge.core.domain.models.Order;
+import br.com.fiap.tech_challenge.core.domain.models.OrderProduct;
+import br.com.fiap.tech_challenge.core.domain.models.enums.OrderStatus;
+import jakarta.persistence.*;
+import org.hibernate.annotations.CreationTimestamp;
+import org.hibernate.annotations.UpdateTimestamp;
+
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.UUID;
+
+@Entity
+@Table(name = "customer_order")
+public class OrderEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private final UUID id;
+
+    @Column(nullable = false)
+    private final BigDecimal amount;
+
+    @Column(nullable = false)
+    private final Integer sequence;
+
+    @Column(nullable = false)
+    @Enumerated(EnumType.STRING)
+    private final OrderStatus status;
+
+    @Column(nullable = false)
+    private final boolean isPaid;
+
+    @Column(nullable = false)
+    private final String paymentId;
+
+    @CreationTimestamp
+    private LocalDateTime createdAt;
+
+    @UpdateTimestamp
+    private LocalDateTime updatedAt;
+
+    private final UUID customerId;
+
+    @OneToMany(mappedBy = "order", cascade = CascadeType.ALL, orphanRemoval = true)
+    private final List<OrderProductEntity> products;
+
+    public OrderEntity(Order order) {
+        this.id = order.getId();
+        this.amount = order.getAmount();
+        this.sequence = order.getSequence();
+        this.status = order.getStatus();
+        this.isPaid = order.isPaid();
+        this.customerId = order.getCustomerId();
+        this.paymentId = order.getPaymentId();
+
+        this.products = order.getProducts().stream().map(
+                orderProduct -> new OrderProductEntity(this, orderProduct)
+        ).toList();
+    }
+
+    public Order toOrder() {
+        List<OrderProduct> orderProducts =
+                products.stream().map(
+                        orderProductEntity -> orderProductEntity.toOrderProduct(id)
+                ).toList();
+
+        return new Order(id, amount, sequence, status, isPaid, orderProducts, customerId, paymentId, createdAt, updatedAt);
+    }
+}

--- a/src/main/java/br/com/fiap/tech_challenge/adapters/driven/infra/entities/OrderProductEntity.java
+++ b/src/main/java/br/com/fiap/tech_challenge/adapters/driven/infra/entities/OrderProductEntity.java
@@ -1,0 +1,44 @@
+package br.com.fiap.tech_challenge.adapters.driven.infra.entities;
+
+import br.com.fiap.tech_challenge.core.domain.models.OrderProduct;
+import jakarta.persistence.*;
+import org.hibernate.annotations.CreationTimestamp;
+
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+@Entity
+@Table(name = "order_product")
+public class OrderProductEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private final UUID id;
+
+    @Column(nullable = false)
+    private final BigDecimal price;
+
+    private final String customization;
+
+    @CreationTimestamp
+    private LocalDateTime createdAt;
+
+    @ManyToOne
+    @JoinColumn(name = "order_id", nullable = false)
+    private final OrderEntity order;
+
+    private final UUID productId;
+
+    public OrderProductEntity(OrderEntity order, OrderProduct orderProduct) {
+        this.order = order;
+        this.id = orderProduct.getId();
+        this.price = orderProduct.getPrice();
+        this.customization = orderProduct.getCustomization();
+        this.productId = orderProduct.getProductId();
+    }
+
+    public OrderProduct toOrderProduct(UUID orderId) {
+        return new OrderProduct(id, price, customization, productId, orderId, createdAt);
+    }
+}

--- a/src/main/java/br/com/fiap/tech_challenge/adapters/driven/infra/repository/OrderPersistenceImpl.java
+++ b/src/main/java/br/com/fiap/tech_challenge/adapters/driven/infra/repository/OrderPersistenceImpl.java
@@ -1,0 +1,37 @@
+package br.com.fiap.tech_challenge.adapters.driven.infra.repository;
+
+import br.com.fiap.tech_challenge.adapters.driven.infra.entities.OrderEntity;
+import br.com.fiap.tech_challenge.core.domain.models.Order;
+import br.com.fiap.tech_challenge.core.domain.ports.OrderPersistence;
+import org.springframework.stereotype.Component;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+
+@Component
+public class OrderPersistenceImpl implements OrderPersistence {
+
+    private final OrderRepository repository;
+
+    public OrderPersistenceImpl(OrderRepository repository) {
+        this.repository = repository;
+    }
+
+    @Override
+    public Order create(Order order) {
+        var orderEntity = new OrderEntity(order);
+        var orderSaved = repository.save(orderEntity);
+        return orderSaved.toOrder();
+    }
+
+    @Override
+    public Integer getLastSequence() {
+        LocalDate today = LocalDate.now();
+        LocalDateTime startOfDay = today.atStartOfDay();
+        LocalDateTime endOfDay = today.atTime(LocalTime.MAX);
+
+        return repository.findLastSequenceForToday(startOfDay, endOfDay).orElse(0);
+    }
+
+}

--- a/src/main/java/br/com/fiap/tech_challenge/adapters/driven/infra/repository/OrderRepository.java
+++ b/src/main/java/br/com/fiap/tech_challenge/adapters/driven/infra/repository/OrderRepository.java
@@ -10,7 +10,6 @@ import java.util.Optional;
 import java.util.UUID;
 
 @Repository
-
 public interface OrderRepository extends JpaRepository<OrderEntity, UUID>{
 
     @Query("SELECT MAX(o.sequence) FROM OrderEntity o WHERE o.createdAt >= :startOfDay AND o.createdAt < :endOfDay")

--- a/src/main/java/br/com/fiap/tech_challenge/adapters/driven/infra/repository/OrderRepository.java
+++ b/src/main/java/br/com/fiap/tech_challenge/adapters/driven/infra/repository/OrderRepository.java
@@ -1,0 +1,18 @@
+package br.com.fiap.tech_challenge.adapters.driven.infra.repository;
+
+import br.com.fiap.tech_challenge.adapters.driven.infra.entities.OrderEntity;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.stereotype.Repository;
+
+import java.time.LocalDateTime;
+import java.util.Optional;
+import java.util.UUID;
+
+@Repository
+
+public interface OrderRepository extends JpaRepository<OrderEntity, UUID>{
+
+    @Query("SELECT MAX(o.sequence) FROM OrderEntity o WHERE o.createdAt >= :startOfDay AND o.createdAt < :endOfDay")
+    Optional<Integer> findLastSequenceForToday(LocalDateTime startOfDay, LocalDateTime endOfDay);
+}

--- a/src/main/java/br/com/fiap/tech_challenge/core/domain/models/Order.java
+++ b/src/main/java/br/com/fiap/tech_challenge/core/domain/models/Order.java
@@ -1,0 +1,78 @@
+package br.com.fiap.tech_challenge.core.domain.models;
+
+import br.com.fiap.tech_challenge.core.domain.models.enums.OrderStatus;
+
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.UUID;
+
+public class Order {
+    private final UUID id;
+    private final BigDecimal amount;
+    private final Integer sequence;
+    private final OrderStatus status;
+    private final boolean isPaid;
+    private final String paymentId;
+    private final List<OrderProduct> products;
+    private final UUID customerId;
+    private final LocalDateTime createdAt;
+    private final LocalDateTime updatedAt;
+
+    public static Order create(BigDecimal amount, Integer sequence, List<OrderProduct> products, UUID customerId, String PaymentId) {
+        return new Order(null, amount, sequence, OrderStatus.RECEIVED, false, products, customerId, PaymentId, null, null);
+    }
+
+    public Order(UUID id, BigDecimal amount, Integer sequence, OrderStatus status, boolean isPaid, List<OrderProduct> products, UUID customerId, String paymentId, LocalDateTime createdAt, LocalDateTime updatedAt) {
+        this.id = id;
+        this.amount = amount;
+        this.sequence = sequence;
+        this.status = status;
+        this.isPaid = isPaid;
+        this.products = products;
+        this.customerId = customerId;
+        this.paymentId = paymentId;
+        this.createdAt = createdAt;
+        this.updatedAt = updatedAt;
+    }
+
+    public UUID getId() {
+        return id;
+    }
+
+    public BigDecimal getAmount() {
+        return amount;
+    }
+
+    public Integer getSequence() {
+        return sequence;
+    }
+
+    public OrderStatus getStatus() {
+        return status;
+    }
+
+    public boolean isPaid() {
+        return isPaid;
+    }
+
+    public LocalDateTime getCreatedAt() {
+        return createdAt;
+    }
+
+    public LocalDateTime getUpdatedAt() {
+        return updatedAt;
+    }
+
+    public List<OrderProduct> getProducts() {
+        return products;
+    }
+
+    public UUID getCustomerId() {
+        return customerId;
+    }
+
+    public String getPaymentId() {
+        return paymentId;
+    }
+}

--- a/src/main/java/br/com/fiap/tech_challenge/core/domain/models/OrderProduct.java
+++ b/src/main/java/br/com/fiap/tech_challenge/core/domain/models/OrderProduct.java
@@ -1,0 +1,44 @@
+package br.com.fiap.tech_challenge.core.domain.models;
+
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+public final class OrderProduct {
+    private final UUID id;
+    private final BigDecimal price;
+    private final String customization;
+    private final UUID productId;
+    private final UUID orderId;
+    private final LocalDateTime createdAt;
+
+    public OrderProduct(UUID id, BigDecimal price, String customization, UUID productId, UUID orderId,
+                        LocalDateTime createdAt) {
+        this.id = id;
+        this.price = price;
+        this.customization = customization;
+        this.productId = productId;
+        this.orderId = orderId;
+        this.createdAt = createdAt;
+    }
+
+    public static OrderProduct create(BigDecimal price, String customization, UUID productId) {
+        return new OrderProduct(null, price, customization, productId, null, null);
+    }
+
+    public UUID getId() {
+        return id;
+    }
+
+    public BigDecimal getPrice() {
+        return price;
+    }
+
+    public String getCustomization() {
+        return customization;
+    }
+
+    public UUID getProductId() {
+        return productId;
+    }
+}

--- a/src/main/java/br/com/fiap/tech_challenge/core/domain/models/enums/OrderStatus.java
+++ b/src/main/java/br/com/fiap/tech_challenge/core/domain/models/enums/OrderStatus.java
@@ -1,0 +1,8 @@
+package br.com.fiap.tech_challenge.core.domain.models.enums;
+
+public enum OrderStatus {
+    RECEIVED,
+    PREPARING,
+    READY,
+    FINISHED;
+}

--- a/src/main/java/br/com/fiap/tech_challenge/core/domain/ports/OrderPersistence.java
+++ b/src/main/java/br/com/fiap/tech_challenge/core/domain/ports/OrderPersistence.java
@@ -1,0 +1,8 @@
+package br.com.fiap.tech_challenge.core.domain.ports;
+
+import br.com.fiap.tech_challenge.core.domain.models.Order;
+
+public interface OrderPersistence {
+    Order create(Order customer);
+    Integer getLastSequence();
+}


### PR DESCRIPTION
In this pull request, we are introducing four new classes to the project: OrderEntity, OrderProductEntity, Order, OrderProduct and OrderRepository. These classes are designed to enhance the structure and management of orders and their associated products within the system.

Details:

OrderEntity
Purpose: Represents the Order entity in the database.

OrderProductEntity
Purpose: Represents the relationship between orders and products in the database.

Order
Purpose: Represents the Order data transfer object used in the application layer.

OrderProductModel
Purpose: Represents the OrderProduct data transfer object used in the application layer.

OrderRepository
Purpose: JPA implementation for OrderEntity.