### PR TITLE
feat: :sparkles: Add create order domain usecase

### DIFF
--- a/src/main/java/br/com/fiap/tech_challenge/core/domain/usecases/order/CreateOrderUseCase.java
+++ b/src/main/java/br/com/fiap/tech_challenge/core/domain/usecases/order/CreateOrderUseCase.java
@@ -1,0 +1,8 @@
+package br.com.fiap.tech_challenge.core.domain.usecases.order;
+
+import br.com.fiap.tech_challenge.core.domain.usecases.order.dto.CreateOrderDTO;
+import br.com.fiap.tech_challenge.core.domain.models.Order;
+
+public interface CreateOrderUseCase {
+    Order create(CreateOrderDTO input);
+}

--- a/src/main/java/br/com/fiap/tech_challenge/core/domain/usecases/order/dto/CreateOrderDTO.java
+++ b/src/main/java/br/com/fiap/tech_challenge/core/domain/usecases/order/dto/CreateOrderDTO.java
@@ -1,0 +1,9 @@
+package br.com.fiap.tech_challenge.core.domain.usecases.order.dto;
+
+import java.util.UUID;
+import java.util.List;
+
+public record CreateOrderDTO(UUID customerId, List<OrderProducts> products) {
+    public record OrderProducts(UUID id, String observation) {
+    }
+}

--- a/src/main/java/br/com/fiap/tech_challenge/core/domain/usecases/order/impl/CreateOrderUseCaseImpl.java
+++ b/src/main/java/br/com/fiap/tech_challenge/core/domain/usecases/order/impl/CreateOrderUseCaseImpl.java
@@ -1,0 +1,70 @@
+package br.com.fiap.tech_challenge.core.domain.usecases.order.impl;
+
+import br.com.fiap.tech_challenge.core.domain.models.Order;
+import br.com.fiap.tech_challenge.core.domain.models.OrderProduct;
+import br.com.fiap.tech_challenge.core.domain.models.Product;
+import br.com.fiap.tech_challenge.core.domain.ports.OrderPersistence;
+import br.com.fiap.tech_challenge.core.domain.ports.ProductPersistence;
+import br.com.fiap.tech_challenge.core.domain.usecases.order.CreateOrderUseCase;
+import br.com.fiap.tech_challenge.core.domain.usecases.order.dto.CreateOrderDTO;
+
+import java.math.BigDecimal;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+import java.util.stream.Collectors;
+
+public class CreateOrderUseCaseImpl implements CreateOrderUseCase {
+
+    private final OrderPersistence persistence;
+    private final ProductPersistence productPersistence;
+
+    public CreateOrderUseCaseImpl(OrderPersistence persistence, ProductPersistence productPersistence) {
+        this.persistence = persistence;
+        this.productPersistence = productPersistence;
+    }
+
+    @Override
+    public Order create(CreateOrderDTO input) {
+        var productIdList = getListOfProductIds(input);
+        var products = productPersistence.findAllByIds(productIdList);
+        var orderProducts = getOrderProducts(input, products);
+        var calculatedAmount = reduceAmount(orderProducts);
+        var nextSequence = getNextSequence();
+
+        Order newOrder = Order.create(calculatedAmount, nextSequence, orderProducts, input.customerId(), "paymentMock");
+
+        return persistence.create(newOrder);
+    }
+
+    private BigDecimal reduceAmount(List<OrderProduct> products) {
+        return products.stream()
+                .map(OrderProduct::getPrice)
+                .reduce(BigDecimal.ZERO, BigDecimal::add);
+    }
+
+    private Integer getNextSequence() {
+        return persistence.getLastSequence() + 1;
+    }
+
+    private List<OrderProduct> getOrderProducts(CreateOrderDTO order, List<Product> products) {
+        Map<UUID, Product> productsMap = products
+                .stream()
+                .collect(Collectors.toMap(Product::getId, product -> product));
+
+        return order
+                .products()
+                .stream()
+                .map(orderProduct -> {
+                    BigDecimal price = productsMap.get(orderProduct.id()).getPrice();
+                    return OrderProduct.create(price, orderProduct.observation(), orderProduct.id());
+                }).toList();
+    }
+
+    private List<UUID> getListOfProductIds(CreateOrderDTO input) {
+        return input.products()
+                .stream()
+                .map(CreateOrderDTO.OrderProducts::id)
+                .collect(Collectors.toList());
+    }
+}


### PR DESCRIPTION
**This PR adds the implementation for the order creation use case.**

Changes Included
Interface CreateOrderUseCase: Defines the contract for order creation.
Implementation CreateOrderUseCaseImpl: Implements the logic to create an order.
Record CreateOrderDTO: Encapsulates the data required to create an order.