### PR TITLE
feat: :sparkles: Add driver API for order create

### DIFF
--- a/src/main/java/br/com/fiap/tech_challenge/adapters/driver/api/controller/OrderController.java
+++ b/src/main/java/br/com/fiap/tech_challenge/adapters/driver/api/controller/OrderController.java
@@ -10,7 +10,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
 @RestController
-@RequestMapping("/api/v1/orders")
+@RequestMapping("/v1/orders")
 public class OrderController {
 
     private final CreateOrderUseCase createOrderUseCase;

--- a/src/main/java/br/com/fiap/tech_challenge/adapters/driver/api/controller/OrderController.java
+++ b/src/main/java/br/com/fiap/tech_challenge/adapters/driver/api/controller/OrderController.java
@@ -1,0 +1,32 @@
+package br.com.fiap.tech_challenge.adapters.driver.api.controller;
+
+import br.com.fiap.tech_challenge.adapters.driver.api.dto.CreateOrderRequestDTO;
+import br.com.fiap.tech_challenge.adapters.driver.api.dto.CreateOrderResponseDTO;
+import br.com.fiap.tech_challenge.adapters.driver.api.mapper.OrderMapper;
+import br.com.fiap.tech_challenge.core.domain.usecases.order.CreateOrderUseCase;
+import jakarta.validation.Valid;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/api/v1/orders")
+public class OrderController {
+
+    private final CreateOrderUseCase createOrderUseCase;
+    private final OrderMapper mapper;
+
+    public OrderController(CreateOrderUseCase createOrderUseCase, OrderMapper mapper) {
+        this.createOrderUseCase = createOrderUseCase;
+        this.mapper = mapper;
+    }
+
+    @PostMapping
+    private ResponseEntity<CreateOrderResponseDTO> create(@RequestBody @Valid CreateOrderRequestDTO orderRequest){
+        var mapperCreateOrder = mapper.toCreateOrder(orderRequest);
+        var order = createOrderUseCase.create(mapperCreateOrder);
+        var response = new CreateOrderResponseDTO(order.getId(), order.getPaymentId());
+
+        return ResponseEntity.status(HttpStatus.CREATED).body(response);
+    }
+}

--- a/src/main/java/br/com/fiap/tech_challenge/adapters/driver/api/dto/CreateOrderRequestDTO.java
+++ b/src/main/java/br/com/fiap/tech_challenge/adapters/driver/api/dto/CreateOrderRequestDTO.java
@@ -1,0 +1,18 @@
+package br.com.fiap.tech_challenge.adapters.driver.api.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotEmpty;
+
+import java.util.List;
+import java.util.UUID;
+
+public record CreateOrderRequestDTO(
+        UUID customerId,
+        @NotEmpty List<OrderProducts> products) {
+
+    public record OrderProducts(
+            @NotBlank UUID id,
+            String observation) {
+
+    }
+}

--- a/src/main/java/br/com/fiap/tech_challenge/adapters/driver/api/dto/CreateOrderResponseDTO.java
+++ b/src/main/java/br/com/fiap/tech_challenge/adapters/driver/api/dto/CreateOrderResponseDTO.java
@@ -1,0 +1,6 @@
+package br.com.fiap.tech_challenge.adapters.driver.api.dto;
+
+import java.util.UUID;
+
+public record CreateOrderResponseDTO(UUID orderId, String qrCode) {
+}

--- a/src/main/java/br/com/fiap/tech_challenge/adapters/driver/api/mapper/OrderMapper.java
+++ b/src/main/java/br/com/fiap/tech_challenge/adapters/driver/api/mapper/OrderMapper.java
@@ -1,0 +1,19 @@
+package br.com.fiap.tech_challenge.adapters.driver.api.mapper;
+
+import br.com.fiap.tech_challenge.adapters.driver.api.dto.CreateOrderRequestDTO;
+import br.com.fiap.tech_challenge.core.domain.usecases.order.dto.CreateOrderDTO;
+import org.springframework.stereotype.Component;
+
+@Component
+public class OrderMapper {
+
+    public CreateOrderDTO toCreateOrder(CreateOrderRequestDTO dto) {
+        return new CreateOrderDTO(
+                dto.customerId(),
+                dto.products().stream().map(orderProducts -> new CreateOrderDTO.OrderProducts(
+                        orderProducts.id(),
+                        orderProducts.observation()
+                )).toList()
+        );
+    }
+}

--- a/src/main/java/br/com/fiap/tech_challenge/config/bean/CreateOrderUseCaseConfig.java
+++ b/src/main/java/br/com/fiap/tech_challenge/config/bean/CreateOrderUseCaseConfig.java
@@ -1,0 +1,18 @@
+package br.com.fiap.tech_challenge.config.bean;
+
+import br.com.fiap.tech_challenge.core.domain.ports.CustomerPersistence;
+import br.com.fiap.tech_challenge.core.domain.ports.OrderPersistence;
+import br.com.fiap.tech_challenge.core.domain.ports.ProductPersistence;
+import br.com.fiap.tech_challenge.core.domain.usecases.customer.impl.CreateCustomerUseCaseImpl;
+import br.com.fiap.tech_challenge.core.domain.usecases.order.impl.CreateOrderUseCaseImpl;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class CreateOrderUseCaseConfig {
+
+    @Bean
+    public CreateOrderUseCaseImpl createOrderUseCaseImpl(OrderPersistence persistence, ProductPersistence productPersistence){
+        return new CreateOrderUseCaseImpl(persistence, productPersistence);
+    }
+}


### PR DESCRIPTION
This PR adds the driver API for order management, including the OrderController, request/response objects, and the configuration for dependency injection of the CreateOrderUseCase.

Changes Included

OrderController:
Adds the REST controller for handling order-related API endpoints.

Includes endpoints POST for creating orders.
Request Object (CreateOrderRequest)
Response Object (CreateOrderResponse)

Dependency Injection Configuration:
Configures the dependency injection for CreateOrderUseCase in the application context.

![order-evidence](https://github.com/user-attachments/assets/92a9ca79-2325-46f1-96de-6f48a6ffab27)
![product-order-evidence](https://github.com/user-attachments/assets/96e956e0-a8ab-488b-9790-afebe9712e5a)
