### PR TITLE
feat: :sparkles: Create endpoint paid order list usecase with API driver

### DIFF
--- a/src/main/java/br/com/fiap/tech_challenge/adapters/driven/infra/gateway/PaymentGatewayImpl.java
+++ b/src/main/java/br/com/fiap/tech_challenge/adapters/driven/infra/gateway/PaymentGatewayImpl.java
@@ -9,7 +9,7 @@ import java.math.BigDecimal;
 public class PaymentGatewayImpl implements PaymentGateway {
     @Override
     public String generatePixQrCode(BigDecimal value) {
-        if(value.compareTo(new BigDecimal("10,00")) == 0) {
+        if(value.compareTo(new BigDecimal("10.00")) == 0) {
             return "mockedUnpaidPixQRCodeString";
         }
         return "mockedPaidPixQRCodeString";

--- a/src/main/java/br/com/fiap/tech_challenge/adapters/driven/infra/repository/OrderPersistenceImpl.java
+++ b/src/main/java/br/com/fiap/tech_challenge/adapters/driven/infra/repository/OrderPersistenceImpl.java
@@ -2,7 +2,10 @@ package br.com.fiap.tech_challenge.adapters.driven.infra.repository;
 
 import br.com.fiap.tech_challenge.adapters.driven.infra.entities.OrderEntity;
 import br.com.fiap.tech_challenge.core.domain.models.Order;
+import br.com.fiap.tech_challenge.core.domain.models.enums.OrderStatus;
 import br.com.fiap.tech_challenge.core.domain.ports.OrderPersistence;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Component;
 
 import java.time.LocalDate;
@@ -41,5 +44,12 @@ public class OrderPersistenceImpl implements OrderPersistence {
         LocalDateTime endOfDay = today.atTime(LocalTime.MAX);
 
         return repository.findLastSequenceForToday(startOfDay, endOfDay).orElse(0);
+    }
+
+    @Override
+    public Page<Order> findByIsPaidAndStatus(Boolean isPaid, OrderStatus status, Pageable pageable) {
+        var orders = repository.findByIsPaidAndStatus(false, status, pageable);
+
+        return orders.map(OrderEntity::toOrder);
     }
 }

--- a/src/main/java/br/com/fiap/tech_challenge/adapters/driven/infra/repository/OrderRepository.java
+++ b/src/main/java/br/com/fiap/tech_challenge/adapters/driven/infra/repository/OrderRepository.java
@@ -1,6 +1,10 @@
 package br.com.fiap.tech_challenge.adapters.driven.infra.repository;
 
 import br.com.fiap.tech_challenge.adapters.driven.infra.entities.OrderEntity;
+import br.com.fiap.tech_challenge.core.domain.models.enums.OrderStatus;
+
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
@@ -14,4 +18,6 @@ public interface OrderRepository extends JpaRepository<OrderEntity, UUID>{
 
     @Query("SELECT MAX(o.sequence) FROM OrderEntity o WHERE o.createdAt >= :startOfDay AND o.createdAt < :endOfDay")
     Optional<Integer> findLastSequenceForToday(LocalDateTime startOfDay, LocalDateTime endOfDay);
+
+    Page<OrderEntity> findByIsPaidAndStatus(Boolean isPaid, OrderStatus status, Pageable pageable);
 }

--- a/src/main/java/br/com/fiap/tech_challenge/adapters/driver/api/controller/OrderController.java
+++ b/src/main/java/br/com/fiap/tech_challenge/adapters/driver/api/controller/OrderController.java
@@ -2,23 +2,57 @@ package br.com.fiap.tech_challenge.adapters.driver.api.controller;
 
 import br.com.fiap.tech_challenge.adapters.driver.api.dto.CreateOrderRequestDTO;
 import br.com.fiap.tech_challenge.adapters.driver.api.dto.CreateOrderResponseDTO;
+import br.com.fiap.tech_challenge.adapters.driver.api.dto.PaidOrdersPaginatedResponseDTO;
 import br.com.fiap.tech_challenge.adapters.driver.api.mapper.OrderMapper;
+import br.com.fiap.tech_challenge.core.domain.models.Order;
+import br.com.fiap.tech_challenge.core.domain.models.enums.OrderStatus;
 import br.com.fiap.tech_challenge.core.domain.usecases.order.CreateOrderUseCase;
+import br.com.fiap.tech_challenge.core.domain.usecases.order.FindPaidOrdersUseCase;
 import jakarta.validation.Valid;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
 
 @RestController
 @RequestMapping("/v1/orders")
 public class OrderController {
 
     private final CreateOrderUseCase createOrderUseCase;
+    private final FindPaidOrdersUseCase findPaidOrdersUseCase;
     private final OrderMapper mapper;
 
-    public OrderController(CreateOrderUseCase createOrderUseCase, OrderMapper mapper) {
+    public OrderController(CreateOrderUseCase createOrderUseCase,
+                           FindPaidOrdersUseCase findPaidOrdersUseCase,
+                           OrderMapper mapper) {
         this.createOrderUseCase = createOrderUseCase;
+        this.findPaidOrdersUseCase = findPaidOrdersUseCase;
         this.mapper = mapper;
+    }
+
+    @GetMapping
+    public ResponseEntity<PaidOrdersPaginatedResponseDTO> findAllIsPaidOrders(@RequestParam("status") OrderStatus status,
+                                                                              Pageable pageable) {
+
+        Page<Order> ordersPage = findPaidOrdersUseCase.findAllPaidOrders(status, pageable);
+
+        List<PaidOrdersPaginatedResponseDTO.OrderSummary> content = ordersPage.getContent().stream()
+                .map(order -> {
+                    var customerName = order.getCustomer() != null ? order.getCustomer().getName() : "";
+                    return new PaidOrdersPaginatedResponseDTO.OrderSummary(
+                            order.getSequence(),
+                            customerName,
+                            order.getCreatedAt(),
+                            order.getUpdatedAt()
+                    );
+                }).toList();
+
+        PaidOrdersPaginatedResponseDTO response = new PaidOrdersPaginatedResponseDTO(content, pageable);
+
+        return ResponseEntity.ok(response);
     }
 
     @PostMapping

--- a/src/main/java/br/com/fiap/tech_challenge/adapters/driver/api/dto/PaidOrdersPaginatedResponseDTO.java
+++ b/src/main/java/br/com/fiap/tech_challenge/adapters/driver/api/dto/PaidOrdersPaginatedResponseDTO.java
@@ -1,0 +1,18 @@
+package br.com.fiap.tech_challenge.adapters.driver.api.dto;
+
+import org.springframework.data.domain.Pageable;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+public record PaidOrdersPaginatedResponseDTO(
+        List<OrderSummary> content,
+        Pageable pageable) {
+
+    public record OrderSummary(
+            Integer sequence,
+            String customerName,
+            LocalDateTime createdAt,
+            LocalDateTime updatedAt) {
+    }
+}

--- a/src/main/java/br/com/fiap/tech_challenge/config/bean/FindPaidOrdersUseCaseConfig.java
+++ b/src/main/java/br/com/fiap/tech_challenge/config/bean/FindPaidOrdersUseCaseConfig.java
@@ -1,0 +1,15 @@
+package br.com.fiap.tech_challenge.config.bean;
+
+import br.com.fiap.tech_challenge.core.domain.ports.OrderPersistence;
+import br.com.fiap.tech_challenge.core.domain.usecases.order.impl.FindPaidOrdersUseCaseImpl;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class FindPaidOrdersUseCaseConfig {
+
+    @Bean
+    public FindPaidOrdersUseCaseImpl findPaidOrdersUseCaseImpl(OrderPersistence persistence) {
+        return new FindPaidOrdersUseCaseImpl(persistence);
+    }
+}

--- a/src/main/java/br/com/fiap/tech_challenge/core/domain/ports/OrderPersistence.java
+++ b/src/main/java/br/com/fiap/tech_challenge/core/domain/ports/OrderPersistence.java
@@ -1,6 +1,9 @@
 package br.com.fiap.tech_challenge.core.domain.ports;
 
 import br.com.fiap.tech_challenge.core.domain.models.Order;
+import br.com.fiap.tech_challenge.core.domain.models.enums.OrderStatus;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 
 import java.util.Optional;
 import java.util.UUID;
@@ -9,4 +12,5 @@ public interface OrderPersistence {
     Optional<Order> findById(UUID id);
     Order create(Order customer);
     Integer getLastSequence();
+    Page<Order> findByIsPaidAndStatus(Boolean isPaid, OrderStatus status, Pageable pageable);
 }

--- a/src/main/java/br/com/fiap/tech_challenge/core/domain/usecases/order/FindPaidOrdersUseCase.java
+++ b/src/main/java/br/com/fiap/tech_challenge/core/domain/usecases/order/FindPaidOrdersUseCase.java
@@ -1,0 +1,10 @@
+package br.com.fiap.tech_challenge.core.domain.usecases.order;
+
+import br.com.fiap.tech_challenge.core.domain.models.Order;
+import br.com.fiap.tech_challenge.core.domain.models.enums.OrderStatus;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+
+public interface FindPaidOrdersUseCase {
+    Page<Order> findAllPaidOrders(OrderStatus status, Pageable pageable);
+}

--- a/src/main/java/br/com/fiap/tech_challenge/core/domain/usecases/order/impl/CreateOrderUseCaseImpl.java
+++ b/src/main/java/br/com/fiap/tech_challenge/core/domain/usecases/order/impl/CreateOrderUseCaseImpl.java
@@ -51,7 +51,7 @@ public class CreateOrderUseCaseImpl implements CreateOrderUseCase {
         var nextSequence = getNextSequence();
         var qrCode = paymentGateway.generatePixQrCode(calculatedAmount);
 
-        var newOrder = Order.create(calculatedAmount, nextSequence, orderProducts, customer, "qrCode");
+        var newOrder = Order.create(calculatedAmount, nextSequence, orderProducts, customer, qrCode);
 
         return persistence.create(newOrder);
     }

--- a/src/main/java/br/com/fiap/tech_challenge/core/domain/usecases/order/impl/CreateOrderUseCaseImpl.java
+++ b/src/main/java/br/com/fiap/tech_challenge/core/domain/usecases/order/impl/CreateOrderUseCaseImpl.java
@@ -38,7 +38,12 @@ public class CreateOrderUseCaseImpl implements CreateOrderUseCase {
 
     @Override
     public Order create(CreateOrderDTO input) {
-        var customer = getCustomer(input.customerId());
+        Customer customer = null;
+
+        if (input.customerId() != null) {
+             customer = getCustomer(input.customerId());
+        }
+
         var productIdList = getListOfProductIds(input);
         var products = productPersistence.findAllByIds(productIdList);
         var orderProducts = getOrderProducts(input, products);
@@ -46,18 +51,14 @@ public class CreateOrderUseCaseImpl implements CreateOrderUseCase {
         var nextSequence = getNextSequence();
         var qrCode = paymentGateway.generatePixQrCode(calculatedAmount);
 
-        var newOrder = Order.create(calculatedAmount, nextSequence, orderProducts, customer, qrCode);
+        var newOrder = Order.create(calculatedAmount, nextSequence, orderProducts, customer, "qrCode");
 
         return persistence.create(newOrder);
     }
 
     private Customer getCustomer(UUID customerId) {
-        if (customerId != null) {
-            return customerPersistence.findById(customerId)
-                    .orElseThrow(() -> new DoesNotExistException("Customer not found with ID: " + customerId));
-        }
-
-        return null;
+        return customerPersistence.findById(customerId)
+                .orElseThrow(() -> new DoesNotExistException("Customer not found with ID: " + customerId));
     }
 
     private BigDecimal reduceAmount(List<OrderProduct> products) {

--- a/src/main/java/br/com/fiap/tech_challenge/core/domain/usecases/order/impl/FindPaidOrdersUseCaseImpl.java
+++ b/src/main/java/br/com/fiap/tech_challenge/core/domain/usecases/order/impl/FindPaidOrdersUseCaseImpl.java
@@ -1,0 +1,23 @@
+package br.com.fiap.tech_challenge.core.domain.usecases.order.impl;
+
+import br.com.fiap.tech_challenge.core.domain.models.Order;
+import br.com.fiap.tech_challenge.core.domain.models.enums.OrderStatus;
+import br.com.fiap.tech_challenge.core.domain.ports.OrderPersistence;
+import br.com.fiap.tech_challenge.core.domain.usecases.order.FindPaidOrdersUseCase;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+
+public class FindPaidOrdersUseCaseImpl implements FindPaidOrdersUseCase {
+
+    private final OrderPersistence persistence;
+
+    public FindPaidOrdersUseCaseImpl(OrderPersistence persistence) {
+        this.persistence = persistence;
+    }
+
+    @Override
+    public Page<Order> findAllPaidOrders(OrderStatus status, Pageable pageable) {
+        Page<Order> orders = persistence.findByIsPaidAndStatus(true, status, pageable);
+        return orders;
+    }
+}


### PR DESCRIPTION
This pull request introduces an endpoint for listing orders, including a use case for fetching paid orders.

Changes:

Add an endpoint to list orders with query parameters.
Implement FindPaidOrdersUseCase to fetch orders with a paid status.
Create request and response objects for the new endpoint.
Configure dependency injection for the new use case.