### PR TITLE
refactor: Changing the Dockerfile images to alpine

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,14 +1,14 @@
-FROM maven:3.9.7-amazoncorretto-21 AS builder
+FROM maven:3.9.8-eclipse-temurin-21-alpine AS builder
 WORKDIR build
 COPY . .
 RUN mvn clean install -DskipTests
 
-FROM amazoncorretto:21.0.2-alpine3.16 AS layers
+FROM eclipse-temurin:21.0.4_7-jre-alpine AS layers
 WORKDIR layer
 COPY --from=builder /build/target/tech-challenge-0.0.1-SNAPSHOT.jar app.jar
 RUN java -Djarmode=layertools -jar app.jar extract
 
-FROM amazoncorretto:21.0.2-alpine3.16
+FROM eclipse-temurin:21.0.4_7-jre-alpine
 WORKDIR /opt/app
 RUN addgroup --system appuser && adduser -S -s /usr/sbin/nologin -G appuser appuser
 COPY --from=layers /layer/dependencies/ ./


### PR DESCRIPTION
Changing the Dockerfile images for the maven and eclipse-temurin alpine versions. These images are considerably smaller, and does not have any vulnerabillities.

![image](https://github.com/user-attachments/assets/56115c95-2fc7-4ea4-b103-420ca853a69d)

![image](https://github.com/user-attachments/assets/fa85172e-e95e-4c83-96d3-b373f0c2eb6a)
