### PR TITLE
fix: 🐛 add idOrder in OrderSummaryResponseDTO

### DIFF
--- a/src/main/java/br/com/fiap/tech_challenge/adapters/driver/api/dto/OrderSummaryResponseDTO.java
+++ b/src/main/java/br/com/fiap/tech_challenge/adapters/driver/api/dto/OrderSummaryResponseDTO.java
@@ -4,13 +4,14 @@ import br.com.fiap.tech_challenge.core.domain.models.order.Order;
 import io.swagger.v3.oas.annotations.media.Schema;
 
 import java.time.LocalDateTime;
+import java.util.UUID;
 
-public record OrderSummaryResponseDTO(@Schema(example = "1") Integer sequence,
-		@Schema(example = "Charles") String customerName,
+public record OrderSummaryResponseDTO(@Schema(example = "ab69e046-fb5a-4a79-98d6-363efdf20e11") UUID id,
+		@Schema(example = "1") Integer sequence, @Schema(example = "Charles") String customerName,
 		@Schema(example = "2024-08-03T01:15:58Z") LocalDateTime createdAt,
 		@Schema(example = "2024-08-03T01:17:58Z") LocalDateTime updatedAt) {
 	public OrderSummaryResponseDTO(Order order) {
-		this(order.getSequence(), order.getCustomer() != null ? order.getCustomer().getName() : null,
+		this(order.getId(), order.getSequence(), order.getCustomer() != null ? order.getCustomer().getName() : null,
 				order.getCreatedAt(), order.getUpdatedAt());
 	}
 }


### PR DESCRIPTION
# fix: 🐛 add idOrder in OrderSummaryResponseDTO

- ID field has been added to the Get Orders DTO

![image](https://github.com/user-attachments/assets/14e48290-4ea3-48c9-9e26-8104573aa479)
