### PR TITLE
docs: 📖 add link of swagger and miro

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,12 +98,13 @@ rodar o seguinte comando: `docker compose up -d`
 ### Swagger
 
 Link para acessar ao swagger após subir a aplicação:
-http://localhost:8357/swagger-ui/index.html#/
+http://localhost:8357/api/swagger-ui/index.html
 
 ### MIRO - Event Storming
 
 Acesso ao MIRO com o Event Storming:
-https://miro.com/welcomeonboard/OFd5QUNidmhXdGhNbmoyZzcwSWR3MmRyeFA5VW5WRlNCcWgxcDBlT1FteENpcmphc09mVHlJaXFOaXlvdTFYaHwzMDc0NDU3MzQ3OTIwNTcxNTU5fDI=?share_link_id=381296204220
+[Event Storming](https://miro.com/welcomeonboard/OFd5QUNidmhXdGhNbmoyZzcwSWR3MmRyeFA5VW5WRlNCcWgxcDBlT1FteENpcmphc09mVHlJaXFOaXlvdTFYaHwzMDc0NDU3MzQ3OTIwNTcxNTU5fDI=?share_link_id=381296204220)
+
 
 ### Contribuição
 

--- a/README.md
+++ b/README.md
@@ -95,6 +95,16 @@ rodar o seguinte comando: `docker compose up -d`
 
 ![Docker compose detached mode](./assets/compose_detached_mode.png)
 
+### Swagger
+
+Link para acessar ao swagger após subir a aplicação:
+http://localhost:8357/swagger-ui/index.html#/
+
+### MIRO - Event Storming
+
+Acesso ao MIRO com o Event Storming:
+https://miro.com/welcomeonboard/OFd5QUNidmhXdGhNbmoyZzcwSWR3MmRyeFA5VW5WRlNCcWgxcDBlT1FteENpcmphc09mVHlJaXFOaXlvdTFYaHwzMDc0NDU3MzQ3OTIwNTcxNTU5fDI=?share_link_id=381296204220
+
 ### Contribuição
 
 Este é um projeto que está em construção pelos desenvolvedores:
@@ -104,7 +114,3 @@ Este é um projeto que está em construção pelos desenvolvedores:
 - Jéssica Rodrigues - RM357218
 - Rodrigo Sartori - RM358002
 - Wilton Souza - RM357991
-
-### Licença
-
-Distribuído sob a licença MIT. Veja LICENSE para mais informações.


### PR DESCRIPTION
Include MIRO with event storming and Swagger link. License removed.